### PR TITLE
Enable custom domains on feed

### DIFF
--- a/.github/workflows/update-feed.yaml
+++ b/.github/workflows/update-feed.yaml
@@ -23,7 +23,9 @@ jobs:
       - name: Install dependencies
         run: npm i
       - name: Build the feed
-        run: npm run build
+        run: |
+           npm run build
+           [ -f CNAME ] && mv CNAME public/CNAME
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:


### PR DESCRIPTION
Include CNAME file (created by Github Pages, which specifies the custom domain) in the public folder, which will become branch `gh-pages`